### PR TITLE
set static_token as not required input, updates descriptions to show you can optionally use environment variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,12 @@
 name: 'Codecov ATS'
-description: 'GitHub Action that returns selected test labels from Codecov☂️  to CI'
+description: 'GitHub Action that returns selected test labels from Codecov☂️ to CI'
 inputs:
   token:
-    description: 'Repository upload token - get it from codecov.io. Required'
+    description: 'Repository upload token - get it from codecov.io. Required or set it with the environment variable CODECOV_TOKEN'
     required: false
   static_token:
-    description: 'Repository static token - get it from codecov.io. Required'
-    required: true
+    description: 'Repository static token - get it from codecov.io. Required or set it with the environment variable CODECOV_STATIC_TOKEN'
+    required: false
   enterprise_url:
     description: 'Change the upload host (Enterprise use only)'
     required: false


### PR DESCRIPTION
- sets `static_token` input as not required
- updates description for `token` and `static_token`
- removes extra space in action's description

I noticed this because the GitHub Actions VS Code extension was complaining that I was missing the `static_token` input when I had defined the action call like so (as shown in the readme):

```yaml
- uses: codecov/codecov-ats@v0.3.0
  env:
    CODECOV_STATIC_TOKEN: ${{ secrets.CODECOV_STATIC_TOKEN }}
    CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

```